### PR TITLE
fixed bug on breadcrumb function

### DIFF
--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -1,5 +1,5 @@
 = render partial: "header"
-- breadcrumb :item_edit
+- breadcrumb :item_edit, @item
 = render "layouts/breadcrumbs"
 .container
   .side-bar

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -1,5 +1,5 @@
 = render partial: "header"
-- breadcrumb :item_show
+- breadcrumb :item_show, @item
 = render "layouts/breadcrumbs"
 .noticeContainer
   -if flash.notice.present?

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -22,8 +22,8 @@ crumb :item_new do
   parent :root
 end
 
-crumb :item_show do
-  link "商品の詳細", item_path(:id)
+crumb :item_show do |item|
+  link "商品の詳細", item_path(params[:id])
   parent :root
 end
 
@@ -32,7 +32,7 @@ crumb :item_confirm do
   parent :item_show
 end
 
-crumb :item_edit do
-  link "商品の編集", edit_item_path
+crumb :item_edit do |item|
+  link "商品の編集", edit_item_path(params[:id])
   parent :item_show
 end


### PR DESCRIPTION
# what
パンくずリストが、商品編集 -> 詳細画面の場合に正常に遷移できないという不具合があったので、修正した。   #39

# why
crumb :item_show の部分できちんと商品のidが紐づいていなかったから。
Couldn't find id='id'のようなエラーが出ていたので、item_pathに(params[:id])を付けることで解決。